### PR TITLE
Allow NM to function without lernstick-firewall

### DIFF
--- a/debian/lernstick-firewall.service
+++ b/debian/lernstick-firewall.service
@@ -21,5 +21,4 @@ NotifyAccess=all
 
 
 [Install]
-WantedBy=network.target
-RequiredBy=dbus-org.freedesktop.nm-dispatcher.service NetworkManager.service
+WantedBy=network.target dbus-org.freedesktop.nm-dispatcher.service NetworkManager.service


### PR DESCRIPTION
We need this for Lernstick EXAM, because otherwise disabling the firwall also causes NM to be stopped.
